### PR TITLE
Register nulldb adapter on foreigner

### DIFF
--- a/lib/foreigner.rb
+++ b/lib/foreigner.rb
@@ -31,6 +31,7 @@ Foreigner::Adapter.register 'postgresql', 'foreigner/connection_adapters/postgre
 Foreigner::Adapter.register 'postgis', 'foreigner/connection_adapters/postgresql_adapter'
 Foreigner::Adapter.register 'jdbcpostgresql', 'foreigner/connection_adapters/postgresql_adapter'
 Foreigner::Adapter.register 'sqlite3', 'foreigner/connection_adapters/noop_adapter'
+Foreigner::Adapter.register 'nulldb', 'foreigner/connection_adapters/noop_adapter'
 
 require 'foreigner/loader'
 require 'foreigner/helper'


### PR DESCRIPTION
#### :tophat: What? Why?

Foreigner doesn't support https://github.com/nulldb/nulldb to avoid hitting the database when precompiling assets. This way it does.
#### :ghost: GIF

![](http://i.giphy.com/3o7TKw4mQEOhQV0XEk.gif)